### PR TITLE
make vm inputs and outputs optional

### DIFF
--- a/src/rxreact.tsx
+++ b/src/rxreact.tsx
@@ -30,8 +30,8 @@ function withViewModelFactory<S, A, P extends S & ActionMap<A>>(
       constructor(props: Difference<P, S & ActionMap<A>>) {
         super(props);
         let viewModel = viewModelFactory(this.propsObservable);
-        this.observableState = combineObservables(viewModel.inputs);
-        this.actions = subjectMapToActionMap(viewModel.outputs);
+        this.observableState = viewModel.inputs ? combineObservables(viewModel.inputs) : Observable.of({}) as Observable<S>;
+        this.actions = viewModel.outputs ? subjectMapToActionMap(viewModel.outputs) : {} as ActionMap<A>;
       }
 
       componentWillMount() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,8 +13,8 @@ export type DiffUnion<T extends string, U extends string> = ({ [P in T]: P } &
   { [P in U]: never } & { [k: string]: never })[T]
 
 export interface ViewModel<S, A> {
-  inputs: ObservableMap<S>
-  outputs: SubjectMap<A>
+  inputs?: ObservableMap<S>
+  outputs?: SubjectMap<A>
 }
 
 export type ViewModelFactory<S, A, P> = (ownProps: Observable<P>) => ViewModel<S, A>

--- a/test/rxreact.test.tsx
+++ b/test/rxreact.test.tsx
@@ -7,6 +7,29 @@ import { mount, ReactWrapper } from "enzyme";
 import { ViewModel } from "../src/types";
 
 describe("withViewModel", () => {
+  describe("given no inputs or outputs", () => {
+    let Component: React.SFC = ({}) => <div>I'm rendered</div>;
+    let rendered: ReactWrapper<any, any>;
+
+    function subject() {
+      let vm = {};
+      let ComponentWithViewModel = withViewModel(vm, Component);
+      return mount(<ComponentWithViewModel />);
+    }
+
+    beforeEach(() => {
+      rendered = subject();
+    });
+    afterEach(() => {
+      rendered.unmount();
+    });
+
+    it("renders immediatly", () => {
+      expect(rendered.exists()).toEqual(true);
+      expect(rendered.text()).toContain("I'm rendered");
+    });
+  });
+
   describe("given a static view model definition", () => {
     let numberSubject: Subject<number> = new Subject();
     let stringSubject: Subject<string> = new Subject();


### PR DESCRIPTION
# Goals

If you have a component that only takes outputs (like a button or whatever), the component will never render because the `observableState` will never emit an event. If a component only takes inputs, the library will throw an error.

# Implementation

- Make inputs and outputs optional
- If one of them is undefined, use a reasonable default

# For discussion

- Is there a cleaner way to handle the defaults, other than casting?