### PR TITLE
feat(View Models): View Models are now composable

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ You connect components to view models by calling `withViewModel`, like so:
 
 ```typescript
 import { withViewModel } from "@rxreact/core";
-let CarComponentWithVm = withViewModel(vm, CarComponent);
+let CarComponentWithVm = withViewModel(vm)(CarComponent);
 ```
 
 This higher order component function produces a new component that is connected to the view model. For each key in the `inputs` of the view model, the component receives a prop of the same name, whose value is populated with the latest value emitted by the Observable given in the view model. For each key in the `outputs` of the view model, the component receives a prop of the same name that is a function which takes a single parameter. When called, that parameter is pushed on the stream emitted by the Subject given in the view model (by calling `.next`).
@@ -140,7 +140,7 @@ let vm = {
     selectCar: selectCar$
   }
 };
-withViewModel(vm, CarComponent) // type error -- car component does not expect someOtherObservable prop
+withViewModel(vm)(CarComponent) // type error -- car component does not expect someOtherObservable prop
 ```
 
 ```typescript
@@ -154,7 +154,7 @@ let vm = {
     selectCar: selectCar$
   }
 };
-withViewModel(vm, CarComponent); // type error -- cars property type does match type emitted by users$ observable
+withViewModel(vm)(CarComponent); // type error -- cars property type does match type emitted by users$ observable
 ```
 
 ```typescript
@@ -175,7 +175,7 @@ let vm = {
     selectCar: selectCar$
   }
 };
-let CarComponentWithVM = withViewModel(vm, CarComponent); // this will actually compile, cause now cars becomes a property that is required by CarComponentWithVM
+let CarComponentWithVM = withViewModel(vm)(CarComponent); // this will actually compile, cause now cars becomes a property that is required by CarComponentWithVM
 
 function CallingComponent({}) {
   return (
@@ -238,7 +238,7 @@ let vmFactory = (ownProps$: Observable<{ car: Car | undefined })) => {
   }
 }
 
-let CarFormComponentWithVM = withViewModel(CarFormComponent)
+let CarFormComponentWithVM = withViewModel(vmFactory)(CarFormComponent)
 ```
 
 Note that this form pattern could be generalized into a library for making reactive forms. In the future, RxReact may offer such a form library.

--- a/test/rxreact.test.tsx
+++ b/test/rxreact.test.tsx
@@ -3,7 +3,6 @@ import { Observable, Subject, combineLatest, of } from "rxjs";
 import { map, startWith, merge } from "rxjs/operators";
 import { withViewModel } from "../src/rxreact";
 import { mount, ReactWrapper } from "enzyme";
-import { ViewModel } from "../src/types";
 
 describe("withViewModel", () => {
   describe("given no inputs or outputs", () => {
@@ -12,7 +11,7 @@ describe("withViewModel", () => {
 
     function subject() {
       let vm = {};
-      let ComponentWithViewModel = withViewModel(vm, Component);
+      let ComponentWithViewModel = withViewModel(vm)(Component);
       return mount(<ComponentWithViewModel />);
     }
 
@@ -78,7 +77,7 @@ describe("withViewModel", () => {
             inputString: stringSubject
           }
         };
-        let ComponentWithViewModel = withViewModel(vm, Component);
+        let ComponentWithViewModel = withViewModel(vm)(Component);
         return mount(<ComponentWithViewModel otherProp={"cheese"} />);
       }
 
@@ -176,7 +175,7 @@ describe("withViewModel", () => {
             inputString: stringSubject
           }
         };
-        let ComponentWithViewModel = withViewModel(vm, Component);
+        let ComponentWithViewModel = withViewModel(vm)(Component);
         return mount(<ComponentWithViewModel otherProp={"cheese"} />);
       }
 
@@ -312,7 +311,7 @@ describe("withViewModel", () => {
       );
     };
 
-    let ComponentWithViewModel = withViewModel(vm, Component);
+    let ComponentWithViewModel = withViewModel(vm)(Component);
 
     let rendered: ReactWrapper<any, any>;
 


### PR DESCRIPTION
Previously for typing the component was passed directly to withViewModel. withViewModel now just
takes the VM or VM factory and can be applied to a component later.

BREAKING CHANGE: Components are not passed to withViewModel, so withViewModel(vm, Component) becomes
withViewModel(vm)(Component)